### PR TITLE
Fix crash when trying to get parent of root dir

### DIFF
--- a/UI/MainWindowObjectBrowser.cs
+++ b/UI/MainWindowObjectBrowser.cs
@@ -46,7 +46,7 @@ namespace Spedit.UI
 		{
 			DirectoryInfo currentInfo = new DirectoryInfo(CurrentObjectBrowserDirectory);
 			DirectoryInfo parentInfo = currentInfo.Parent;
-			if (parentInfo.Exists)
+			if (parentInfo != null && parentInfo.Exists)
 			{
 				ChangeObjectBrowserToDirectory(parentInfo.FullName);
 			}


### PR DESCRIPTION
SPEdit crashes with exception 'System.NullreferenceException' when trying to get parents of root directorys (e.g C:\).
Note: EXE debugged with dnSpy not Visual Studio.